### PR TITLE
remove SESAPS18 hyperlinks - destination no longer online

### DIFF
--- a/data/talks.json
+++ b/data/talks.json
@@ -313,7 +313,7 @@
   ],
   [
     "APS Southeastern section meeting",
-    "http://www.phys.utk.edu/SESAPS18/",
+    "",
     "2018-11",
     "Jerrica Wilson",
     "Probing the Quark-Gluon Plasma: comparison of experimental jet dat to theoretical calculations",
@@ -321,7 +321,7 @@
   ],
   [
     "APS Southeastern section meeting",
-    "http://www.phys.utk.edu/SESAPS18/",
+    "",
     "2018-11",
     "James Neuhaus",
     "New heavy ion infrastructure in RIVET-HI",
@@ -329,7 +329,7 @@
   ],
   [
     "APS Southeastern section meeting",
-    "http://www.phys.utk.edu/SESAPS18/",
+    "",
     "2018-11",
     "Austin Schmier",
     "Improving predictions of the Quark-Gluon Plasma",
@@ -337,7 +337,7 @@
   ],
   [
     "APS Southeastern section meeting",
-    "http://www.phys.utk.edu/SESAPS18/",
+    "",
     "2018-11",
     "Mariah McCreary",
     "Comparison of Azimuthal Anisotropy calculations in heavy ion collisions",


### PR DESCRIPTION
This removes the hyperlinks to the the SESAPS18 event. The link destination is no longer online.