### PR TITLE
add headers parameter to linkchecker requests.get

### DIFF
--- a/tests/linkchecker.py
+++ b/tests/linkchecker.py
@@ -16,7 +16,8 @@ def check_url(url, file):
         # replace any backslash with forward slash
         url = url.replace('\\', '/')
 
-        response = requests.get(url, timeout=30)
+        headers = {'User-Agent': 'Mozilla/5.0'}
+        response = requests.get(url, headers=headers, timeout=30)
 
         if response.status_code == 200:
             # print('Checking url: ' + url + ' in file: ' + file)


### PR DESCRIPTION
This PR resolves an issue where one of the sites that we link to stopped responding to our link checker's get request.  With this additional header parameter, the unresponsive site now responds with status code 200.

https://github.com/JETSCAPE/JETSCAPE.github.io/actions/runs/14687178585/job/41217373897
