### PR TITLE
remove broken dropbox hyperlinks

### DIFF
--- a/data/talks.json
+++ b/data/talks.json
@@ -137,7 +137,7 @@
   ],
   [
     "APS April Meeting 2021",
-    "https://april.aps.org/",
+    "https://meetings.aps.org/Meeting/APR21/Content/4017",
     "2021-04",
     "James Mulligan",
     "Determining the jet transport coefficient of the quark-gluon plasma using Bayesian parameter estimation",

--- a/data/talks.json
+++ b/data/talks.json
@@ -29,7 +29,7 @@
     "2021-11-15",
     "Chun Shen",
     "Multi-Messenger Heavy-ion Physics with JETSCAPE",
-    "https://www.dropbox.com/s/9zv8b2ssw2mtxl2/Multi-MessengerJETSCAPE.pdf?dl=0"
+    ""
   ],
   [
     "APS DNP 2023",
@@ -141,7 +141,7 @@
     "2021-04",
     "James Mulligan",
     "Determining the jet transport coefficient of the quark-gluon plasma using Bayesian parameter estimation",
-    "https://www.dropbox.com/s/o0tojky1mbn3t43/20210417_Mulligan_APS_v1.pdf?dl=0"
+    ""
   ],
   [
     "Moriond",
@@ -149,7 +149,7 @@
     "2021-04",
     "James Mulligan",
     "Determining the jet transport coefficient of the quark-gluon plasma using Bayesian parameter estimation",
-    "https://www.dropbox.com/s/if6y1c9agy27g9m/20210402_Mulligan_Moriond_v2.pdf?dl=0"
+    ""
   ],
   [
     "Heavy-ion tea seminar",
@@ -165,7 +165,7 @@
     "2020-10",
     "Amit Kumar",
     "Jet quenching in a multi-stage Monte Carloapproach",
-    "https://www.dropbox.com/s/oz1tp6qutv9seum/AmitKumar_DNP_Meeting_2020.pdf?dl=0"
+    ""
   ],
   [
     "APS DNP 2020",
@@ -173,7 +173,7 @@
     "2020-10",
     "Gojko Vujanovic",
     "Probing multi-scale dynamicalinteractions between heavy quarksand the QGP using JETSCAPE",
-    "https://www.dropbox.com/s/lraekt3heq3igmg/Gojko_Vujanovic_DB00001.pdf?dl=0"
+    ""
   ],
   [
     "APS DNP 2020",
@@ -181,7 +181,7 @@
     "2020-10",
     "Wenkai Fan",
     "Heavy jet evolution in QGP using the JETSCAPE framework",
-    "https://www.dropbox.com/s/xvp86tok1gv1m3r/WenkaiFan_DNP_talk_2020.pdf?dl=0"
+    ""
   ],
   [
     "Hard Probes 2020",
@@ -197,7 +197,7 @@
     "2020-06",
     "Chathuranga Sirimanna",
     "Photon-jet correlations in p-p and Pb-Pbcollisions using JETSCAPE framework",
-    "https://www.dropbox.com/s/uj3hw0auy47e1tw/PhotonJetCorrelation_Chathuranga_v3.pdf?dl=0"
+    ""
   ],
   [
     "Hard Probes 2020",
@@ -205,7 +205,7 @@
     "2020-06",
     "Michael Kordell",
     "First Results from HybridHadronization in Smalland Large Systems",
-    "https://www.dropbox.com/s/xpr7l6e07es3mef/Kordell_HP2020_v2.pptx?dl=0"
+    ""
   ],
   [
     "Hard Probes 2020",
@@ -229,7 +229,7 @@
     "2019-11",
     "Yasuki Tachibana",
     "Hydrodynamic response to jets with a source based on causal diffusion",
-    "https://www.dropbox.com/s/575yykwhdrmoozt/tachibana_qm19_v2.pdf?dl=0"
+    ""
   ],
   [
     "Quark Matter 2019",
@@ -245,7 +245,7 @@
     "2019-11",
     "James Mulligan",
     "The JETSCAPE Framework (for ep and eA collisions?)",
-    "https://www.dropbox.com/s/0xwr315dfr4smx1/20191121_Jetscape_MCEG_workshop.pdf?dl=0"
+    ""
   ],
   [
     "Quark Matter 2019",
@@ -253,7 +253,7 @@
     "2019-11",
     "Jean-Francois Paquet",
     "Multi-system Bayesian constraints on the transport coefficients of QCD",
-    "https://www.dropbox.com/s/gqislq1x3oujpct/qm2019_jfpaquet_jetscape_sims_draft20.pdf?dl=0"
+    ""
   ],
   [
     "Quark Matter 2019",
@@ -261,7 +261,7 @@
     "2019-11",
     "Ron Soltz",
     "A Comprehensive MC Framework for Jet Quenching",
-    "https://www.dropbox.com/s/xdjdzkxft3cw9ax/mc_jetquench_framework_qm19_soltz.pdf?dl=0"
+    ""
   ],
   [
     "APS DNP 2019",
@@ -269,7 +269,7 @@
     "2019-10",
     "Chathuranga Sirimanna",
     "DNP_Fall_Meeting_2019",
-    "https://www.dropbox.com/work/Collaboration-Access/Collaboration-Only-Files/JETSCAPE_talks/2019/DNP_Fall_Meeting_2019?preview=DNP2019_Chathuranga.pdf"
+    ""
   ],
   [
     "APS DNP 2019",
@@ -277,7 +277,7 @@
     "2019-10",
     "Ron Soltz",
     "Extraction of q-hat with correlated experimental errors",
-    "https://www.dropbox.com/s/e5t6gq391qalw0v/bayesian_qhat_errs_dnp19_soltz.pdf?dl=0"
+    ""
   ],
   [
     "RHIC/AGS User's Meeting",
@@ -285,7 +285,7 @@
     "2019-06",
     "Yasuki Tachibana",
     "Status of JETSCAPE ",
-    "https://www.dropbox.com/s/w5hs2b651p55m3a/yasuki_tachibana_RHICAGS_June19.pdf?dl=0"
+    ""
   ],
   [
     "Jet Tools Bergen",
@@ -301,7 +301,7 @@
     "2019-03",
     "Wenkai Fan",
     "Heavy Jet Observables within the JETSCAPE Framework",
-    "https://www.dropbox.com/s/ewqe9smd2b3d6w7/HIghpTWorkshop_Lido%2BJetScape_v3.pdf?dl=0"
+    ""
   ],
   [
     "Sante Fe/UCLA Jet and HF Workshop",
@@ -309,7 +309,7 @@
     "2019-01",
     "Weiyao Ke",
     "Model-to-data Comparison with JETSCAPE: a Heavy Flavor Example",
-    "https://www.dropbox.com/s/eqrnngzk31u6i02/UCLA-jet-HF-2019-Weiyao-Ke-v2.pdf?dl=0"
+    ""
   ],
   [
     "APS Southeastern section meeting",
@@ -317,7 +317,7 @@
     "2018-11",
     "Jerrica Wilson",
     "Probing the Quark-Gluon Plasma: comparison of experimental jet dat to theoretical calculations",
-    "https://www.dropbox.com/s/uhi35e5kbmp2mi5/SESAPSWilson.pdf?dl=0"
+    ""
   ],
   [
     "APS Southeastern section meeting",
@@ -325,7 +325,7 @@
     "2018-11",
     "James Neuhaus",
     "New heavy ion infrastructure in RIVET-HI",
-    "https://www.dropbox.com/s/f1ekwxbb6xgrmcz/SESAPS-Neuhaus.pdf?dl=0"
+    ""
   ],
   [
     "APS Southeastern section meeting",
@@ -333,7 +333,7 @@
     "2018-11",
     "Austin Schmier",
     "Improving predictions of the Quark-Gluon Plasma",
-    "https://www.dropbox.com/s/64m8o0xbxsewmjs/SchmierSESAPS.pdf?dl=0"
+    ""
   ],
   [
     "APS Southeastern section meeting",
@@ -341,7 +341,7 @@
     "2018-11",
     "Mariah McCreary",
     "Comparison of Azimuthal Anisotropy calculations in heavy ion collisions",
-    "https://www.dropbox.com/s/tbcy9ady8arvste/McCrearySESAPS2018.pdf?dl=0"
+    ""
   ],
   [
     "Hard Probes 2018",
@@ -349,7 +349,7 @@
     "2018-10",
     "Yasuki Tachibana",
     "Jet substructure modifications in a QGP from multi-scale description of jet evolution with JETSCAPE",
-    "https://www.dropbox.com/s/qv1vx03i7jpmq1y/tachibana_hp_18_v4.pdf?dl=0"
+    ""
   ],
   [
     "Hard Probes 2018",
@@ -357,7 +357,7 @@
     "2018-10",
     "Ron Soltz",
     "Bayesian extraction of $\\hat{q}$ with a multi-stage jet evolution approach",
-    "https://www.dropbox.com/s/7fw0csa3bthdysb/bayesian_qhat_hp18_jetscape_soltz.pdf?dl=0"
+    ""
   ],
   [
     "Hard Probes 2018",
@@ -365,7 +365,7 @@
     "2018-10",
     "Rainer Fries",
     "p+p physics with the JETSCAPE 1.0 framework",
-    "https://www.dropbox.com/s/zq95ifv2hqm5ftw/HP2018_pp_Fries_v4.pdf?dl=0"
+    ""
   ],
   [
     "Hard Probes 2018",
@@ -373,7 +373,7 @@
     "2018-10",
     "Chanwook Park",
     "Multi-stage jet evolution through QGP using the JETSCAPE framework: inclusive jets, correlations and leading hadrons",
-    "https://www.dropbox.com/s/ac77js2nws4vaj7/Chanwook_Park_HP2018_v3.pdf?dl=0"
+    ""
   ],
   [
     "Hard Probes 2018",
@@ -381,7 +381,7 @@
     "2018-10",
     "Joern Putschke",
     "JETSCAPE 1.0: The first software release of the JETSCAPE collaboration",
-    "https://www.dropbox.com/s/pvvys7v3c64f5bq/hp18_poster_putschke_v1.pdf?dl=0"
+    ""
   ],
   [
     "RIVET Workshop, Copenhagen",
@@ -389,7 +389,7 @@
     "2018-09",
     "Dani Pablos",
     "RIVET for JETSCAPE",
-    "https://www.dropbox.com/s/4w5f74f2t6b1b2e/pablos_rivet_cph_v2.pdf?dl=0"
+    ""
   ],
   [
     "Electron - Ion Collider User Group Meeting 2018",
@@ -397,7 +397,7 @@
     "2018-07",
     "Joern Putschke",
     "JETSCAPE 1.0",
-    "https://www.dropbox.com/s/1u2znze241nhg7r/eic_ug_jetscape_v1.pdf?dl=0"
+    ""
   ],
   [
     "2018 Workshop on Probing Quark-Gluon Matter with Jets",
@@ -405,7 +405,7 @@
     "2018-07",
     "Chun Shen",
     "JETSCAPE 1.0",
-    "https://www.dropbox.com/s/2dtyf1msi1w2xb1/jetscape_1.0_cshen.pdf?dl=0"
+    ""
   ],
   [
     "RHIC/AGS User's Meeting",
@@ -413,7 +413,7 @@
     "2018-06",
     "Joern Putschke",
     "JETSCAPE 1.0",
-    "https://www.dropbox.com/s/92tozm2fedblc2r/ags_jetscape_putschke.pdf?dl=0"
+    ""
   ],
   [
     "Quark Matter 2018",
@@ -421,7 +421,7 @@
     "2018-05",
     "Kolja Kauder",
     "JETSCAPE 1.0 - First release",
-    "https://www.dropbox.com/s/6ipceqk8r6jm2m2/Kauder_QM18_Jetscape.pptx?dl=0"
+    ""
   ],
   [
     "INT Workshop",
@@ -429,7 +429,7 @@
     "2017-05",
     "Gojko Vujanovic",
     "Electromagnetic probes of heavy ion collisions",
-    "https://www.dropbox.com/s/fxxyw26mfw6wiiw/Vujanovic_INT-17-1b.pdf?dl=0"
+    ""
   ],
   [
     "INT Workshop",
@@ -437,7 +437,7 @@
     "2017-05",
     "Shanshan Cao",
     "Transport model for heavy quark / jet and its possible future development",
-    "https://www.dropbox.com/s/ycigzufeiro53r1/CaoWeek4.pdf?dl=0"
+    ""
   ],
   [
     "INT Workshop",
@@ -445,7 +445,7 @@
     "2017-05",
     "Shanshan Cao",
     "Multistage Jet Evolution in Heavy-Ion Collisions",
-    "https://www.dropbox.com/s/b5575ig50wyyhzf/CaoWeek2.pdf?dl=0"
+    ""
   ],
   [
     "INT Workshop",
@@ -453,7 +453,7 @@
     "2017-05",
     "Shanshan Cao",
     "Transport model for heavy quark / jet and its possible future development",
-    "https://www.dropbox.com/s/2vy7zsk3515ryyw/CaoWeek1.pdf?dl=0"
+    ""
   ],
   [
     "Quark Matter 2017",
@@ -461,7 +461,7 @@
     "2017-02",
     "Gojko Vujanovic",
     "Bulk viscous effects on flow and dilepton radiation in a hybrid approach",
-    "https://www.dropbox.com/s/goj64wiv1ph3avh/Vujanovic_QM2017.pdf?dl=0"
+    ""
   ],
   [
     "Quark Matter 2017",
@@ -469,7 +469,7 @@
     "2017-02",
     "Dennis Bazow",
     "GPU-optimized fluid dynamics for heavy ion collisions",
-    "https://www.dropbox.com/s/tqvy30b6f91rruo/QM2017_Bazow.pdf?dl=0"
+    ""
   ],
   [
     "Hard Probes 2016",
@@ -477,6 +477,6 @@
     "2016-09",
     "Gojko Vujanovic",
     "Bulk viscous effects on flow and dilepton radiation in a hybrid approach",
-    "https://www.dropbox.com/s/glt2rzuw6tl6c0w/Vujanovic_HP2016_newrepo.pdf?dl=0"
+    ""
   ]
 ]


### PR DESCRIPTION
This PR removes broken dropbox hyperlinks on the Talks page, while leaving the plain text titles.